### PR TITLE
#163386219 Configure code climate to ignore test files for maintainability 

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -13,3 +13,6 @@ checks:
 
 exclude_patterns:
   - "src/serviceWorker.js"
+  - "src/actions/__tests__/"
+  - "src/reducers/__tests__/"
+  - "**/*.spec.jsx"


### PR DESCRIPTION
#### What does this PR do?
Ignore test files from being covered on maintainability
#### Description of Task to be completed?
Code climate has been checking test files (.spec.jsx) files when computing maintainability. I have excluded those files from being covered by the code climate.
#### What are the relevant pivotal tracker stories?
- 163386219
#### Screenshots
##### Ignored files on the current develop branch
<img width="1022" alt="screen shot 2019-01-22 at 15 25 03" src="https://user-images.githubusercontent.com/32167860/51535623-103f8900-1e5a-11e9-9bd2-48b55ec34e73.png">
