### PR TITLE
#162163237 Users should be able to share articles on social media and via email

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "bootstrap-css-only": "^4.2.1",
     "axios": "^0.18.0",
     "axios-mock-adapter": "^1.16.0",
+    "bootstrap-css-only": "^4.2.1",
     "classnames": "^2.2.6",
     "dotenv": "^6.2.0",
     "enzyme": "^3.8.0",
@@ -27,6 +27,7 @@
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
     "react-scripts": "2.1.3",
+    "react-share": "^2.4.0",
     "react-social-icons": "^4.1.0",
     "react-test-renderer": "^16.7.0",
     "react-toastify": "^4.5.2",

--- a/src/components/ShareArticleButtons/ShareArticleButtons.jsx
+++ b/src/components/ShareArticleButtons/ShareArticleButtons.jsx
@@ -1,0 +1,37 @@
+import React from "react";
+import {
+  FacebookShareButton,
+  TwitterShareButton,
+  EmailShareButton,
+  FacebookIcon,
+  TwitterIcon,
+  EmailIcon
+} from "react-share";
+
+export const ShareArticleButtons = () => (
+  <div>
+    <FacebookShareButton
+      className="share-button"
+      url={window.location.href}
+      style={{ marginBottom: "8px" }}
+    >
+      <FacebookIcon size={32} round />
+    </FacebookShareButton>
+    <TwitterShareButton
+      className="share-button"
+      url={window.location.href}
+      style={{ marginBottom: "8px" }}
+    >
+      <TwitterIcon size={32} round />
+    </TwitterShareButton>
+    <EmailShareButton
+      className="share-button"
+      url={window.location.href}
+      style={{ marginBottom: "8px" }}
+    >
+      <EmailIcon size={32} round />
+    </EmailShareButton>
+  </div>
+);
+
+export default ShareArticleButtons;

--- a/src/components/ShareArticleButtons/ShareArticleButtons.spec.jsx
+++ b/src/components/ShareArticleButtons/ShareArticleButtons.spec.jsx
@@ -1,0 +1,18 @@
+import { shallow } from "enzyme";
+import React from "react";
+import { ShareArticleButtons } from "./ShareArticleButtons";
+
+describe("Share article buttons tests", () => {
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallow(<ShareArticleButtons />);
+  });
+
+  it("should match the snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should render 3 share buttons", () => {
+    expect(wrapper.find(".share-button").length).toBe(3);
+  });
+});

--- a/src/components/ShareArticleButtons/__snapshots__/ShareArticleButtons.spec.jsx.snap
+++ b/src/components/ShareArticleButtons/__snapshots__/ShareArticleButtons.spec.jsx.snap
@@ -1,0 +1,403 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Share article buttons tests should match the snapshot 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ShareArticleButtons />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <CreatedButton
+          className="share-button"
+          style={
+            Object {
+              "marginBottom": "8px",
+            }
+          }
+          url="http://localhost/"
+          windowHeight={400}
+          windowWidth={550}
+        >
+          <Icon
+            className=""
+            iconBgStyle={Object {}}
+            logoFillColor="white"
+            round={true}
+            size={32}
+          />
+        </CreatedButton>,
+        <CreatedButton
+          className="share-button"
+          style={
+            Object {
+              "marginBottom": "8px",
+            }
+          }
+          url="http://localhost/"
+          windowHeight={400}
+          windowWidth={550}
+        >
+          <Icon
+            className=""
+            iconBgStyle={Object {}}
+            logoFillColor="white"
+            round={true}
+            size={32}
+          />
+        </CreatedButton>,
+        <CreatedButton
+          className="share-button"
+          onClick={[Function]}
+          openWindow={false}
+          style={
+            Object {
+              "marginBottom": "8px",
+            }
+          }
+          url="http://localhost/"
+        >
+          <Icon
+            className=""
+            iconBgStyle={Object {}}
+            logoFillColor="white"
+            round={true}
+            size={32}
+          />
+        </CreatedButton>,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "children": <Icon
+            className=""
+            iconBgStyle={Object {}}
+            logoFillColor="white"
+            round={true}
+            size={32}
+          />,
+          "className": "share-button",
+          "style": Object {
+            "marginBottom": "8px",
+          },
+          "url": "http://localhost/",
+          "windowHeight": 400,
+          "windowWidth": 550,
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "className": "",
+            "iconBgStyle": Object {},
+            "logoFillColor": "white",
+            "round": true,
+            "size": 32,
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "children": <Icon
+            className=""
+            iconBgStyle={Object {}}
+            logoFillColor="white"
+            round={true}
+            size={32}
+          />,
+          "className": "share-button",
+          "style": Object {
+            "marginBottom": "8px",
+          },
+          "url": "http://localhost/",
+          "windowHeight": 400,
+          "windowWidth": 550,
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "className": "",
+            "iconBgStyle": Object {},
+            "logoFillColor": "white",
+            "round": true,
+            "size": 32,
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "children": <Icon
+            className=""
+            iconBgStyle={Object {}}
+            logoFillColor="white"
+            round={true}
+            size={32}
+          />,
+          "className": "share-button",
+          "onClick": [Function],
+          "openWindow": false,
+          "style": Object {
+            "marginBottom": "8px",
+          },
+          "url": "http://localhost/",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "className": "",
+            "iconBgStyle": Object {},
+            "logoFillColor": "white",
+            "round": true,
+            "size": 32,
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        "type": [Function],
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <CreatedButton
+            className="share-button"
+            style={
+              Object {
+                "marginBottom": "8px",
+              }
+            }
+            url="http://localhost/"
+            windowHeight={400}
+            windowWidth={550}
+          >
+            <Icon
+              className=""
+              iconBgStyle={Object {}}
+              logoFillColor="white"
+              round={true}
+              size={32}
+            />
+          </CreatedButton>,
+          <CreatedButton
+            className="share-button"
+            style={
+              Object {
+                "marginBottom": "8px",
+              }
+            }
+            url="http://localhost/"
+            windowHeight={400}
+            windowWidth={550}
+          >
+            <Icon
+              className=""
+              iconBgStyle={Object {}}
+              logoFillColor="white"
+              round={true}
+              size={32}
+            />
+          </CreatedButton>,
+          <CreatedButton
+            className="share-button"
+            onClick={[Function]}
+            openWindow={false}
+            style={
+              Object {
+                "marginBottom": "8px",
+              }
+            }
+            url="http://localhost/"
+          >
+            <Icon
+              className=""
+              iconBgStyle={Object {}}
+              logoFillColor="white"
+              round={true}
+              size={32}
+            />
+          </CreatedButton>,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "children": <Icon
+              className=""
+              iconBgStyle={Object {}}
+              logoFillColor="white"
+              round={true}
+              size={32}
+            />,
+            "className": "share-button",
+            "style": Object {
+              "marginBottom": "8px",
+            },
+            "url": "http://localhost/",
+            "windowHeight": 400,
+            "windowWidth": 550,
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "className": "",
+              "iconBgStyle": Object {},
+              "logoFillColor": "white",
+              "round": true,
+              "size": 32,
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "children": <Icon
+              className=""
+              iconBgStyle={Object {}}
+              logoFillColor="white"
+              round={true}
+              size={32}
+            />,
+            "className": "share-button",
+            "style": Object {
+              "marginBottom": "8px",
+            },
+            "url": "http://localhost/",
+            "windowHeight": 400,
+            "windowWidth": 550,
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "className": "",
+              "iconBgStyle": Object {},
+              "logoFillColor": "white",
+              "round": true,
+              "size": 32,
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "children": <Icon
+              className=""
+              iconBgStyle={Object {}}
+              logoFillColor="white"
+              round={true}
+              size={32}
+            />,
+            "className": "share-button",
+            "onClick": [Function],
+            "openWindow": false,
+            "style": Object {
+              "marginBottom": "8px",
+            },
+            "url": "http://localhost/",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "className": "",
+              "iconBgStyle": Object {},
+              "logoFillColor": "white",
+              "round": true,
+              "size": 32,
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          "type": [Function],
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getDerivedStateFromProps": true,
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/src/views/Articles/articleView/ArticleView.jsx
+++ b/src/views/Articles/articleView/ArticleView.jsx
@@ -9,6 +9,7 @@ import {
 } from "../../../actions/articleActions/ArticleActions";
 import RoundButton from "../../../components/RoundButton/RoundButton";
 import "./ArticleView.scss";
+import ShareButtons from "../../../components/ShareArticleButtons/ShareArticleButtons";
 
 export class ArticleView extends Component {
   constructor(props) {
@@ -80,9 +81,12 @@ export class ArticleView extends Component {
             handleLink={this.handleLink}
           />
 
-          <div className="container page mt-5">
+          <div className="article-body container page mt-5">
             <div className="row article-content">
-              <div className="col-xs-12">
+              <div className="sidebar col-xs-1" style={{ marginRight: "50px" }}>
+                <ShareButtons />
+              </div>
+              <div className="col-md-11">
                 <div>{renderHTML(articleIfo.body)}</div>
 
                 <ul className="tag-list" color="secondary">
@@ -100,7 +104,6 @@ export class ArticleView extends Component {
                 </ul>
               </div>
             </div>
-
             <hr />
           </div>
         </div>

--- a/src/views/Articles/articleView/ArticleView.scss
+++ b/src/views/Articles/articleView/ArticleView.scss
@@ -1,7 +1,12 @@
 ul {
   display: flex;
   flex-direction: row;
+
   li {
     list-style: none;
   }
+}
+
+.share-button:hover {
+  cursor: pointer;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1942,7 +1942,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.6.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -3392,7 +3392,7 @@ debounce@^1.1.0:
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
   integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
 
-debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.1.2, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -6781,6 +6781,13 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
+jsonp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/jsonp/-/jsonp-0.2.1.tgz#a65b4fa0f10bda719a05441ea7b94c55f3e15bae"
+  integrity sha1-pltPoPEL2nGaBUQep7lMVfPhW64=
+  dependencies:
+    debug "^2.1.3"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -9772,6 +9779,16 @@ react-scripts@2.1.3:
     workbox-webpack-plugin "3.6.3"
   optionalDependencies:
     fsevents "1.2.4"
+
+react-share@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/react-share/-/react-share-2.4.0.tgz#e033316760cfe3265bf0cb031373a7564dbf92f5"
+  integrity sha512-PlVs9Z0/ma0LDaVOPC9uWEysucoL2OOnBEFu7m4TjFMiS42KmHDTW9k9L4LOCCpxiHemfrg/EkzHuU2YXJHn8g==
+  dependencies:
+    babel-runtime "^6.6.1"
+    classnames "^2.2.5"
+    jsonp "^0.2.1"
+    prop-types "^15.5.8"
 
 react-social-icons@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
#### What does this PR do?
Enable Author's Haven users to share articles on facebook, twitter, and email.

#### Description of tasks to be completed?
Install a helper package for social sharing on react: `react-share`
Create a functional component to render the 3 sharing buttons
For maintainability and quality code, write unit tests that cover this feature's functionality

#### How can this be manually tested?
Go to the PR review app (attached below), log in and navigate to one article (read more). Click on any of the sharing buttons.
This open a new tab or bring up a pop up in which you are prompted to login (not logged in) OR you are prompted to edit the post you are about to share (tweet or post).

#### What are the relevant pivotal tracker stories?
[#162163237
](https://www.pivotaltracker.com/story/show/162163237)

#### Screenshots
Twitter sharing
![image](https://user-images.githubusercontent.com/5712103/51667812-d8f3e800-1fd1-11e9-9562-e212a70e22a6.png)

Facebook sharing
![image](https://user-images.githubusercontent.com/5712103/51667847-f1640280-1fd1-11e9-8f4a-208b073e14a3.png)
